### PR TITLE
Switch to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "histutils"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Import, export or merge zsh or fish history files."
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- update cargo manifest to Rust 2024 edition

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a0109910a08326ba915c1870402e3c