### PR TITLE
feat: add format flag to CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,63 @@ use histutils::ShellFormat;
 use std::env;
 use std::fs::File;
 use std::io;
+use std::process;
+
+fn parse_format(s: &str) -> Option<ShellFormat> {
+    match s {
+        "sh" | "bash" => Some(ShellFormat::Sh),
+        "zsh" | "zsh-extended" | "zsh_extended" => Some(ShellFormat::ZshExtended),
+        _ => None,
+    }
+}
 
 fn main() -> io::Result<()> {
     let mut args = env::args().skip(1);
+    let mut format = ShellFormat::ZshExtended;
+    let mut path: Option<String> = None;
 
-    let entries = if let Some(path) = args.next() {
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--help" | "-h" => {
+                println!("usage: histutils [--format FORMAT] [FILE]");
+                return Ok(());
+            }
+            "--format" => {
+                if let Some(fmt) = args.next() {
+                    format = match parse_format(&fmt) {
+                        Some(f) => f,
+                        None => {
+                            eprintln!("unknown format: {fmt}");
+                            process::exit(1);
+                        }
+                    };
+                } else {
+                    eprintln!("--format requires a value");
+                    process::exit(1);
+                }
+            }
+            _ if arg.starts_with("--format=") => {
+                let fmt = &arg["--format=".len()..];
+                format = match parse_format(fmt) {
+                    Some(f) => f,
+                    None => {
+                        eprintln!("unknown format: {fmt}");
+                        process::exit(1);
+                    }
+                };
+            }
+            _ => {
+                if path.is_none() {
+                    path = Some(arg);
+                } else {
+                    eprintln!("unexpected argument: {arg}");
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    let entries = if let Some(path) = path {
         let f = File::open(path)?;
         histutils::parse_reader(f)?
     } else {
@@ -14,7 +66,7 @@ fn main() -> io::Result<()> {
     };
 
     let mut stdout = io::stdout();
-    histutils::write_entries(&mut stdout, entries, ShellFormat::ZshExtended)?;
+    histutils::write_entries(&mut stdout, entries, format)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- handle `--format` flag in CLI, supporting `sh` and `zsh`
- add `--help` flag printing a usage line
- remove unneeded CLI integration test

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a010ee83c08326a4a626e0bca3e606