### PR TITLE
Add version flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,11 @@ fn main() -> io::Result<()> {
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--help" | "-h" => {
-                println!("usage: histutils [--format FORMAT] [FILE]");
+                println!("usage: histutils [--format FORMAT] [--version] [FILE]");
+                return Ok(());
+            }
+            "--version" | "-V" => {
+                println!("{}", env!("CARGO_PKG_VERSION"));
                 return Ok(());
             }
             "--format" => {


### PR DESCRIPTION
## Summary
- Add `--version`/`-V` CLI flags using `CARGO_PKG_VERSION`
- Revert README changes to keep usage concise

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68a0163ea9488326a47184c40a5548a9