### PR TITLE
Add fish history format parsing and serialization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ fn parse_format(s: &str) -> Option<ShellFormat> {
     match s {
         "sh" | "bash" => Some(ShellFormat::Sh),
         "zsh" | "zsh-extended" | "zsh_extended" => Some(ShellFormat::ZshExtended),
+        "fish" => Some(ShellFormat::Fish),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- support parsing fish history entries with custom YAML-like syntax
- add serialization for fish format and CLI option
- detect fish format once per file rather than per line
- test parsing of fish entries with multiple paths
- escape and unescape paths in fish history entries

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0164747708326a982e065014bd793