### PR TITLE
Fix clippy collapsible if warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,18 +20,18 @@ pub fn parse_reader<R: Read>(reader: R) -> io::Result<Vec<HistoryEntry>> {
     let buf_reader = io::BufReader::new(reader);
     let mut lines = buf_reader.lines().peekable();
 
-    if let Some(Ok(first_line)) = lines.peek() {
-        if first_line.trim_start().starts_with("- cmd:") {
-            while let Some(line_res) = lines.next() {
-                let line = line_res?;
-                if line.trim_start().starts_with("- cmd:") {
-                    if let Some(entry) = parse_fish_entry(line, &mut lines) {
-                        entries.push(entry);
-                    }
-                }
+    if let Some(Ok(first_line)) = lines.peek()
+        && first_line.trim_start().starts_with("- cmd:")
+    {
+        while let Some(line_res) = lines.next() {
+            let line = line_res?;
+            if line.trim_start().starts_with("- cmd:")
+                && let Some(entry) = parse_fish_entry(line, &mut lines)
+            {
+                entries.push(entry);
             }
-            return Ok(entries);
         }
+        return Ok(entries);
     }
 
     while let Some(line_res) = lines.next() {


### PR DESCRIPTION
## Summary
- simplify fish history parsing by collapsing nested `if` statements

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68a01f7ee6a48326bd99588cd13a2b2e