### PR TITLE
Warn on invalid history lines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,8 @@ fn main() -> io::Result<()> {
     }
 
     let entries = if let Some(path) = path {
-        let f = File::open(path)?;
-        histutils::parse_reader(f)?
+        let f = File::open(&path)?;
+        histutils::parse_reader_with_path(f, &path)?
     } else {
         histutils::parse_reader(io::stdin())?
     };


### PR DESCRIPTION
## Summary
- emit warnings for invalid history entries with file path and line number
- track line numbers while parsing fish history

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0211601508326bbc98f907ce6ea14