### PR TITLE
Pin Rust toolchain for consistent CI linting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install Rust toolchain
+        run: rustup show
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.89.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
- pin Rust toolchain 1.89.0 with clippy and rustfmt components
- ensure CI installs the pinned toolchain before running checks

## Testing
- ⚠️ `cargo fmt --all` *(failed to download Rust 1.89.0: unsuccessful tunnel)*
- ✅ `RUSTUP_TOOLCHAIN=1.88.0 cargo fmt --all`
- ⚠️ `cargo clippy --all-targets --all-features -- -D warnings` *(failed to download Rust 1.89.0: unsuccessful tunnel)*
- ✅ `RUSTUP_TOOLCHAIN=1.88.0 cargo clippy --all-targets --all-features -- -D warnings`
- ⚠️ `cargo build` *(failed to download Rust 1.89.0: unsuccessful tunnel)*
- ✅ `RUSTUP_TOOLCHAIN=1.88.0 cargo build`
- ⚠️ `cargo test` *(failed to download Rust 1.89.0: unsuccessful tunnel)*
- ✅ `RUSTUP_TOOLCHAIN=1.88.0 cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a02179174c832686e1f84fdf9e1bbb