### PR TITLE
Fix extra blank lines in fish format output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,9 @@ where
             while let Some(path_res) = lines.peek() {
                 let path_line = path_res.as_ref().ok()?;
                 let ps = path_line.trim_start();
-                if ps.starts_with("- ") {
+                if ps.starts_with("- cmd:") {
+                    break;
+                } else if ps.starts_with("- ") {
                     let line = lines.next().unwrap().ok()?;
                     let ps = line.trim_start();
                     paths.push(unescape_fish(&ps[2..]));
@@ -222,7 +224,6 @@ fn write_fish_format<W: Write, I: IntoIterator<Item = HistoryEntry>>(
                 writeln!(writer, "    - {}", escape_fish(&p))?;
             }
         }
-        writeln!(writer)?;
     }
     Ok(())
 }
@@ -456,14 +457,27 @@ mod tests {
 
         let result = String::from_utf8(output).expect("valid utf8");
         let expected =
-            "- cmd: cargo build\n  when: 1700000000\n  paths:\n    - ~/Developer/histutils\n\n";
+            "- cmd: cargo build\n  when: 1700000000\n  paths:\n    - ~/Developer/histutils\n";
         assert_eq!(result, expected);
     }
 
     #[test]
     fn roundtrip_fish_multiline() {
         let original =
-            "- cmd: echo hello\\nworld\n  when: 1700000001\n\n- cmd: ls\n  when: 1700000002\n\n";
+            "- cmd: echo hello\\nworld\n  when: 1700000001\n- cmd: ls\n  when: 1700000002\n";
+        let reader = Cursor::new(original);
+        let entries = parse_reader(reader).expect("should parse");
+
+        let mut output = Vec::new();
+        write_entries(&mut output, entries, ShellFormat::Fish).expect("should write");
+        let result = String::from_utf8(output).expect("valid utf8");
+
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn roundtrip_fish_with_paths() {
+        let original = "- cmd: cargo build\n  when: 1700000000\n  paths:\n    - ~/Developer/histutils\n- cmd: ls\n  when: 1700000001\n";
         let reader = Cursor::new(original);
         let entries = parse_reader(reader).expect("should parse");
 
@@ -503,7 +517,7 @@ mod tests {
         let mut output = Vec::new();
         write_entries(&mut output, entries, ShellFormat::Fish).expect("should write");
         let result = String::from_utf8(output).expect("valid utf8");
-        assert_eq!(result, "- cmd: one\\ntwo\\\\\n  when: 0\n\n");
+        assert_eq!(result, "- cmd: one\\ntwo\\\\\n  when: 0\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Stop emitting a trailing blank line for each fish history entry
- Ensure fish parser stops path parsing when a new entry begins
- Update and extend tests for fish formatting

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68a022b6ddf483269bd8b26ad980083f