### PR TITLE
Specify minimum supported Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "histutils"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.86"
 description = "Import, export or merge zsh or fish history files."
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- declare Rust 1.86 as the minimum supported compiler version

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0387fbbc083269acafbd369536b90