### PR TITLE
Restrict public API to used functions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,8 @@
-use histutils::ShellFormat;
+use histutils::{ShellFormat, parse_format};
 use std::env;
 use std::fs::File;
 use std::io;
 use std::process;
-
-fn parse_format(s: &str) -> Option<ShellFormat> {
-    match s {
-        "sh" | "bash" => Some(ShellFormat::Sh),
-        "zsh" | "zsh-extended" | "zsh_extended" => Some(ShellFormat::ZshExtended),
-        "fish" => Some(ShellFormat::Fish),
-        _ => None,
-    }
-}
 
 fn main() -> io::Result<()> {
     let mut args = env::args().skip(1);
@@ -64,9 +55,9 @@ fn main() -> io::Result<()> {
             let f = File::open(p)?;
             readers.push((f, p.clone()));
         }
-        histutils::parse_readers_with_paths(readers)?
+        histutils::parse_readers(readers)?
     } else {
-        histutils::parse_reader(io::stdin())?
+        histutils::parse_readers([(io::stdin(), "-")])?
     };
 
     let mut stdout = io::stdout();


### PR DESCRIPTION
## Summary
- expose only main.rs's needed functions: `parse_format`, `parse_readers`, and `write_entries`
- remove unused `parse_reader` and `parse_readers` helpers and keep their logic internal
- update main and tests to rely solely on the public API
- pass reader/path pairs to `parse_readers` using tuple arrays, avoiding temporary vectors

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68a03bff3848832695b76592633afd71