### PR TITLE
chore: enforce warning-free builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ name: Rust
 on: push
 
 env:
+  RUSTFLAGS: "-Dwarnings"
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -16,7 +17,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features
 
       - name: Build
         run: cargo build --verbose


### PR DESCRIPTION
## Summary
- ensure CI fails on Rust warnings by setting `RUSTFLAGS: "-Dwarnings"`
- rely on `RUSTFLAGS` for Clippy and drop redundant `-D warnings`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68a041f9fa4483268c8e8a4d004189ba