### PR TITLE
Add multi-format merge test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -653,6 +653,24 @@ mod tests {
     }
 
     #[test]
+    fn merge_different_format_histories() {
+        let sh = Cursor::new("echo sh\n");
+        let zsh = Cursor::new(": 1:0;echo zsh\n");
+        let fish = Cursor::new("- cmd: echo fish\n  when: 2\n");
+
+        let entries =
+            parse_readers([(sh, "sh"), (zsh, "zsh"), (fish, "fish")]).expect("should parse");
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].command, "echo sh");
+        assert_eq!(entries[1].command, "echo zsh");
+        assert_eq!(entries[2].command, "echo fish");
+        assert_eq!(entries[0].timestamp, 0);
+        assert_eq!(entries[1].timestamp, 1);
+        assert_eq!(entries[2].timestamp, 2);
+    }
+
+    #[test]
     fn parse_fish_entry_handles_escapes() {
         let input = "- cmd: first\\nsecond\\\\third\\x\n  when: 1700000000\n";
         let reader = Cursor::new(input);


### PR DESCRIPTION
## Summary
- add test merging sh, zsh, and fish history formats into one vector

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68a042f474288326a8a753e1f8b50fc1