### PR TITLE
feat: add count flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ Migrate formats.
 $ cat ~/.zsh_history | histutils --format fish
 $ cat ~/.local/share/fish/fish_history | histutils --format zsh
 ```
+
+Count entries in a history file.
+
+```
+$ histutils --count ~/.zsh_history
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,16 +8,20 @@ fn main() -> io::Result<()> {
     let mut args = env::args().skip(1);
     let mut format = ShellFormat::ZshExtended;
     let mut paths: Vec<String> = Vec::new();
+    let mut count = false;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--help" | "-h" => {
-                println!("usage: histutils [--format FORMAT] [--version] [FILE...]");
+                println!("usage: histutils [--format FORMAT] [--count] [--version] [FILE...]");
                 return Ok(());
             }
             "--version" | "-V" => {
                 println!("{}", env!("CARGO_PKG_VERSION"));
                 return Ok(());
+            }
+            "--count" | "-c" => {
+                count = true;
             }
             "--format" => {
                 if let Some(fmt) = args.next() {
@@ -57,9 +61,12 @@ fn main() -> io::Result<()> {
         }
         histutils::parse_readers(readers)?
     };
-
-    let mut stdout = io::stdout();
-    histutils::write_entries(&mut stdout, entries, format)?;
+    if count {
+        println!("{}", entries.len());
+    } else {
+        let mut stdout = io::stdout();
+        histutils::write_entries(&mut stdout, entries, format)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- support `--count`/`-c` to print history entry totals instead of entries
- document `--count` usage in CLI help and README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a045d08d408326a8d683280b3a52b0