### PR TITLE
Eliminate unneeded clones for cleaner history handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
 use std::io::{self, BufRead, Read, Write};
 use std::path::Path;
 
@@ -41,11 +42,13 @@ where
     P: AsRef<Path>,
     I: IntoIterator<Item = (R, P)>,
 {
-    let mut seen: HashSet<HistoryEntry> = HashSet::new();
+    let mut seen: HashSet<u64> = HashSet::new();
     let mut entries = Vec::new();
     for (reader, path) in readers {
         for entry in parse_reader(reader, path)? {
-            if seen.insert(entry.clone()) {
+            let mut hasher = DefaultHasher::new();
+            entry.hash(&mut hasher);
+            if seen.insert(hasher.finish()) {
                 entries.push(entry);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,9 +55,9 @@ fn main() -> io::Result<()> {
         histutils::parse_readers([(io::stdin(), "-")])?
     } else {
         let mut readers = Vec::new();
-        for p in &paths {
-            let f = File::open(p)?;
-            readers.push((f, p.clone()));
+        for p in paths {
+            let f = File::open(&p)?;
+            readers.push((f, p));
         }
         histutils::parse_readers(readers)?
     };


### PR DESCRIPTION
## Summary
- iterate over file paths by value to avoid cloning in the CLI
- deduplicate parsed entries via hashing to remove extra clones

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a048462ff0832699d0dff6376a0608