### PR TITLE
feat: detect shell history format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,15 @@
 use histutils::{ShellFormat, parse_format};
 use std::env;
 use std::fs::File;
-use std::io;
+use std::io::{self, Read, Seek};
 use std::process;
+
+trait ReadSeek: Read + Seek {}
+impl<T: Read + Seek> ReadSeek for T {}
 
 fn main() -> io::Result<()> {
     let mut args = env::args().skip(1);
-    let mut format = ShellFormat::ZshExtended;
+    let mut format: Option<ShellFormat> = None;
     let mut paths: Vec<String> = Vec::new();
     let mut count = false;
 
@@ -26,7 +29,7 @@ fn main() -> io::Result<()> {
             "--format" => {
                 if let Some(fmt) = args.next() {
                     format = if let Some(f) = parse_format(&fmt) {
-                        f
+                        Some(f)
                     } else {
                         eprintln!("unknown format: {fmt}");
                         process::exit(1);
@@ -39,7 +42,7 @@ fn main() -> io::Result<()> {
             _ if arg.starts_with("--format=") => {
                 let fmt = &arg["--format=".len()..];
                 format = if let Some(f) = parse_format(fmt) {
-                    f
+                    Some(f)
                 } else {
                     eprintln!("unknown format: {fmt}");
                     process::exit(1);
@@ -51,21 +54,34 @@ fn main() -> io::Result<()> {
         }
     }
 
-    let entries = if paths.is_empty() {
-        histutils::parse_readers([(io::stdin(), "-")])?
+    let mut inputs: Vec<(Box<dyn ReadSeek>, String)> = Vec::new();
+    if paths.is_empty() {
+        let mut buf = Vec::new();
+        io::stdin().read_to_end(&mut buf)?;
+        inputs.push((Box::new(io::Cursor::new(buf)), "-".to_string()));
     } else {
-        let mut readers = Vec::new();
         for p in paths {
             let f = File::open(&p)?;
-            readers.push((f, p));
+            inputs.push((Box::new(f), p));
         }
-        histutils::parse_readers(readers)?
-    };
+    }
+
+    if format.is_none() {
+        let detected = histutils::detect_format(inputs.iter_mut().map(|(r, _)| r.as_mut()))?;
+        format = detected;
+        if format.is_none() {
+            eprintln!("could not detect history format; please specify --format");
+            process::exit(1);
+        }
+    }
+
+    let entries = histutils::parse_readers(inputs.into_iter())?;
+
     if count {
         println!("{}", entries.len());
     } else {
         let mut stdout = io::stdout();
-        histutils::write_entries(&mut stdout, entries, format)?;
+        histutils::write_entries(&mut stdout, entries, format.unwrap())?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- add `detect_format` to infer shell history format across inputs
- auto-detect CLI output format when none specified
- error if multiple input formats are mixed

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0bce003008326add303f8e1d84a95