### PR TITLE
handle duplicate CLI flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,11 @@ fn parse_args(args: &[String]) -> Result<Config, ArgError> {
                 config.print_version = true;
             }
             "--count" | "-c" => {
+                if config.count {
+                    return Err(ArgError(
+                        "usage: --count specified multiple times".to_string(),
+                    ));
+                }
                 config.count = true;
             }
             "--output" | "-o" => {
@@ -133,6 +138,11 @@ fn parse_args(args: &[String]) -> Result<Config, ArgError> {
                 }
             }
             "--epoch" => {
+                if config.epoch.is_some() {
+                    return Err(ArgError(
+                        "usage: --epoch specified multiple times".to_string(),
+                    ));
+                }
                 if let Some(epoch_str) = args.next() {
                     if let Ok(e) = epoch_str.parse::<u64>() {
                         config.epoch = Some(e);
@@ -144,6 +154,11 @@ fn parse_args(args: &[String]) -> Result<Config, ArgError> {
                 }
             }
             "--output-format" => {
+                if config.output_format.is_some() {
+                    return Err(ArgError(
+                        "usage: --output-format specified multiple times".to_string(),
+                    ));
+                }
                 if let Some(fmt) = args.next() {
                     config.output_format = if let Some(f) = parse_format_opt(fmt) {
                         Some(f)
@@ -155,6 +170,11 @@ fn parse_args(args: &[String]) -> Result<Config, ArgError> {
                 }
             }
             _ if arg.starts_with("--output-format=") => {
+                if config.output_format.is_some() {
+                    return Err(ArgError(
+                        "usage: --output-format specified multiple times".to_string(),
+                    ));
+                }
                 let fmt = &arg["--output-format=".len()..];
                 config.output_format = if let Some(f) = parse_format_opt(fmt) {
                     Some(f)
@@ -163,6 +183,11 @@ fn parse_args(args: &[String]) -> Result<Config, ArgError> {
                 };
             }
             _ if arg.starts_with("--epoch=") => {
+                if config.epoch.is_some() {
+                    return Err(ArgError(
+                        "usage: --epoch specified multiple times".to_string(),
+                    ));
+                }
                 let epoch_str = &arg["--epoch=".len()..];
                 if let Ok(e) = epoch_str.parse::<u64>() {
                     config.epoch = Some(e);

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -240,6 +240,33 @@ fn writes_to_output_file() {
 }
 
 #[test]
+fn count_specified_multiple_times() {
+    let output = histutils(&["--count", "--count"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stderr, "usage: --count specified multiple times\n");
+}
+
+#[test]
+fn epoch_specified_multiple_times() {
+    let output = histutils(&["--epoch", "1", "--epoch", "2"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stderr, "usage: --epoch specified multiple times\n");
+}
+
+#[test]
+fn output_format_specified_multiple_times() {
+    let output = histutils(&["--output-format=fish", "--output-format=sh"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stderr, "usage: --output-format specified multiple times\n");
+}
+
+#[test]
 fn overwrites_existing_output_file() {
     let input_str = ": 123:0;echo hello\n";
     let input_file = TempFile::with_content(input_str);


### PR DESCRIPTION
## Summary
- error if --count, --epoch or --output-format are given multiple times
- test duplicate flag behaviour

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a4070fce0c83269f9de29d4600d960