### PR TITLE
Drop epoch flag and default missing timestamps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,6 @@ impl ShellFormat {
 
 #[derive(Debug, Default, Clone)]
 pub struct Context {
-    pub epoch: Option<u64>,
     pub filename: Option<PathBuf>,
 }
 
@@ -103,12 +102,11 @@ where
     }
 }
 
-/// Parses history entries from multiple files and fallback timestamp epoch.
+/// Parses history entries from multiple files.
 ///
 /// # Arguments
 ///
 /// * `files` - An iterator of `HistoryFile` instances to parse and analyze.
-/// * `epoch` - Fallback timestamp epoch to use if no timestamp is found.
 ///
 /// # Returns
 ///
@@ -378,7 +376,7 @@ where
         }
 
         Some(Ok(HistoryEntry {
-            timestamp: ctx.epoch,
+            timestamp: None,
             duration: None,
             command,
             paths: None,


### PR DESCRIPTION
## Summary
- remove `--epoch` CLI option and context field
- auto-assign current timestamp when exporting to zsh or fish and warn once
- update tests for new timestamp behavior
- assert exact warning text in timestamp tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68a4aa8940788326ba9c11e4bc3a5c2d