### PR TITLE
refine path merge semantics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,18 +193,33 @@ fn merge_entries(mut a: HistoryEntry, b: HistoryEntry) -> HistoryEntry {
         _ => {}
     }
 
-    // Merge paths uniquely
-    match (&mut a.paths, b.paths) {
-        (None, Some(b_paths)) => a.paths = Some(b_paths),
+    // Prefer non-empty paths from either side; if both have paths, keep `a`'s.
+    a.paths = match (a.paths.take(), b.paths) {
         (Some(a_paths), Some(b_paths)) => {
-            for p in b_paths {
-                if !a_paths.contains(&p) {
-                    a_paths.push(p);
-                }
+            if a_paths.is_empty() && !b_paths.is_empty() {
+                Some(b_paths)
+            } else if a_paths.is_empty() && b_paths.is_empty() {
+                None
+            } else {
+                Some(a_paths)
             }
         }
-        _ => {}
-    }
+        (Some(a_paths), None) => {
+            if a_paths.is_empty() {
+                None
+            } else {
+                Some(a_paths)
+            }
+        }
+        (None, Some(b_paths)) => {
+            if b_paths.is_empty() {
+                None
+            } else {
+                Some(b_paths)
+            }
+        }
+        (None, None) => None,
+    };
 
     a
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1061,8 +1061,8 @@ mod fish {
     }
 
     #[test]
-    fn merges_entries_with_paths() {
-        // Test that when merging duplicate entries, paths are merged uniquely
+    fn merges_entries_prefers_first_paths() {
+        // When merging duplicate entries, if both have paths, keep the first entry's paths.
         let temp_file1 =
             TempFile::with_content("- cmd: cargo build\n  when: 1000\n  paths:\n    - /tmp\n");
         let temp_file2 =
@@ -1077,11 +1077,11 @@ mod fish {
 
         assert!(output.status.success());
         let stdout = String::from_utf8(output.stdout).expect("failed to convert to string");
-        // Should deduplicate and merge paths
+        // Should keep paths from the first file only
         assert!(stdout.contains("cargo build"));
         assert!(stdout.contains("paths:"));
         assert!(stdout.contains("- /tmp"));
-        assert!(stdout.contains("- /home"));
+        assert!(!stdout.contains("- /home"));
         // Should only have one entry
         assert_eq!(stdout.matches("cargo build").count(), 1);
     }


### PR DESCRIPTION
## Summary
- prefer non-empty paths from one side when merging; keep first entry's paths when both have
- adjust path merging test to validate first-file preference
- run rustfmt

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c27fe89c8326a6f8fa0543e24d42