### PR TITLE
Treat zsh history as zsh extended format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Import, export or merge zsh or fish history files.
 Merge multiple history files into a single file.
 
 ```
-$ histutils --output-format zsh ~/.zsh_sessions/*.history
+$ histutils --output-format zsh-extended ~/.zsh_sessions/*.history
 ```
 
 Migrate formats.
 
 ```
 $ cat ~/.zsh_history | histutils --output-format fish
-$ cat ~/.local/share/fish/fish_history | histutils --output-format zsh
+$ cat ~/.local/share/fish/fish_history | histutils --output-format zsh-extended
 ```
 
 Count entries in a history file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ impl ShellFormat {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Sh => "sh",
-            Self::ZshExtended => "zsh",
+            Self::ZshExtended => "zsh-extended",
             Self::Fish => "fish",
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ fn parse_args(args: &[String]) -> Result<Config, ArgError> {
 fn parse_format_opt(s: &str) -> Option<ShellFormat> {
     match s {
         "sh" | "bash" => Some(ShellFormat::Sh),
-        "zsh" => Some(ShellFormat::ZshExtended),
+        "zsh-extended" | "zsh" => Some(ShellFormat::ZshExtended),
         "fish" => Some(ShellFormat::Fish),
         _ => None,
     }


### PR DESCRIPTION
## Summary
- Recognize `zsh-extended` as the canonical format, keeping `zsh` as alias
- Document usage with `--output-format zsh-extended`
- Restore short descriptions to mention zsh history files
- Format README with Prettier

## Testing
- `prettier --write README.md`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ea0bc8448326819f722fc04b24ad