### PR TITLE
Add zsh-extended format with zsh alias

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "histutils"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.86"
-description = "Import, export or merge zsh or fish history files."
+description = "Import, export or merge zsh extended or fish history files."
 license = "MIT"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # histutils
 
-Import, export or merge zsh or fish history files.
+Import, export or merge zsh extended or fish history files.
 
 ## Usage
 
 Merge multiple history files into a single file.
 
 ```
-$ histutils --output-format zsh ~/.zsh_sessions/*.history
+$ histutils --output-format zsh-extended ~/.zsh_sessions/*.history
 ```
 
 Migrate formats.
 
 ```
 $ cat ~/.zsh_history | histutils --output-format fish
-$ cat ~/.local/share/fish/fish_history | histutils --output-format zsh
+$ cat ~/.local/share/fish/fish_history | histutils --output-format zsh-extended
 ```
 
 Count entries in a history file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ impl ShellFormat {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Sh => "sh",
-            Self::ZshExtended => "zsh",
+            Self::ZshExtended => "zsh-extended",
             Self::Fish => "fish",
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ fn parse_args(args: &[String]) -> Result<Config, ArgError> {
 fn parse_format_opt(s: &str) -> Option<ShellFormat> {
     match s {
         "sh" | "bash" => Some(ShellFormat::Sh),
-        "zsh" => Some(ShellFormat::ZshExtended),
+        "zsh" | "zsh-extended" => Some(ShellFormat::ZshExtended),
         "fish" => Some(ShellFormat::Fish),
         _ => None,
     }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -575,7 +575,7 @@ mod zsh {
     }
 
     #[test]
-    fn sh_to_zsh_sets_timestamp() {
+    fn sh_to_zsh_alias_sets_timestamp() {
         let data_file = test_data_file("sh_history");
         let output = histutils(&["--output-format", "zsh", &data_file]);
         assert!(output.status.success());
@@ -598,7 +598,7 @@ mod zsh {
 
         let output = histutils(&[
             "--output-format",
-            "zsh",
+            "zsh-extended",
             temp_file1.path_str(),
             temp_file2.path_str(),
         ]);
@@ -617,7 +617,7 @@ mod zsh {
         let input_data = test_data_file("fish_common_history");
         let expected_output_str = test_data_str("zsh_common_history");
 
-        let output = histutils(&["--output-format", "zsh", &input_data]);
+        let output = histutils(&["--output-format", "zsh-extended", &input_data]);
         let actual_output_str =
             String::from_utf8(output.stdout).expect("failed to convert to string");
 
@@ -630,7 +630,7 @@ mod zsh {
         let data_file = test_data_file("zsh_common_history");
         let input_str = test_data_str("zsh_common_history");
 
-        let output = histutils(&["--output-format", "zsh", &data_file]);
+        let output = histutils(&["--output-format", "zsh-extended", &data_file]);
         let output_str = String::from_utf8(output.stdout).expect("failed to convert to string");
 
         assert!(output.status.success());
@@ -646,7 +646,8 @@ mod zsh {
         let fish_str = String::from_utf8(fish_output.stdout).expect("failed to convert to string");
         assert!(fish_str.contains("- cmd: echo �"));
 
-        let zsh_output = histutils_with_stdin(&["--output-format", "zsh"], fish_str.as_bytes());
+        let zsh_output =
+            histutils_with_stdin(&["--output-format", "zsh-extended"], fish_str.as_bytes());
         assert!(zsh_output.status.success());
         let zsh_str = String::from_utf8(zsh_output.stdout).expect("failed to convert to string");
         assert!(zsh_str.contains(": 1700000012:0;echo �"));
@@ -657,7 +658,7 @@ mod zsh {
         let data_file = test_data_file("zsh_duration_history");
         let input_str = test_data_str("zsh_duration_history");
 
-        let output = histutils(&["--output-format", "zsh", &data_file]);
+        let output = histutils(&["--output-format", "zsh-extended", &data_file]);
         let output_str = String::from_utf8(output.stdout).expect("failed to convert to string");
 
         assert!(output.status.success());
@@ -679,7 +680,7 @@ mod zsh {
     fn zsh_bad_history_to_zsh() {
         let data_file = test_data_file("zsh_bad_history");
 
-        let output = histutils(&["--output-format", "zsh", &data_file]);
+        let output = histutils(&["--output-format", "zsh-extended", &data_file]);
 
         assert!(output.status.success());
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -890,7 +891,7 @@ mod fish {
     fn roundtrip_fish_zsh_replacement_char() {
         let data_file = test_data_file("fish_common_history");
 
-        let zsh_output = histutils(&["--output-format", "zsh", &data_file]);
+        let zsh_output = histutils(&["--output-format", "zsh-extended", &data_file]);
         assert!(zsh_output.status.success());
         let zsh_str = String::from_utf8(zsh_output.stdout).expect("failed to convert to string");
         assert!(zsh_str.contains(": 1700000012:0;echo �"));


### PR DESCRIPTION
## Summary
- treat zsh history as `zsh-extended` internally
- accept `--output-format zsh-extended` while keeping `zsh` as an alias
- document new canonical name

## Testing
- `cargo fmt --all`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ff8ca3648326a6b9dec87e6bb1fa